### PR TITLE
Bugfix:FIC is allotting IP address twice for the same key

### DIFF
--- a/pkg/provider/sqlite/store.go
+++ b/pkg/provider/sqlite/store.go
@@ -19,6 +19,7 @@ package sqlite
 import (
 	"database/sql"
 	"fmt"
+
 	log "github.com/F5Networks/f5-ipam-controller/pkg/vlogger"
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -182,7 +183,7 @@ func (store *DBStore) GetIPAddress(ipamLabel, hostname string) string {
 		return ""
 	}
 
-	queryString = fmt.Sprintf("SELECT status FROM ipaddress_range where ipaddress=%s AND ipam_label=\"%s\" order by id ASC limit 1",
+	queryString = fmt.Sprintf("SELECT status FROM ipaddress_range where ipaddress=\"%s\" AND ipam_label=\"%s\" order by id ASC limit 1",
 		ipaddress,
 		ipamLabel,
 	)


### PR DESCRIPTION
Bugfix: FIC is allotting IP address twice for the same key after restarting of FIC controller.

signed-off by: Amit Gupta amitg2812@gmail.com
