### PR TITLE
Add Status subresource to IPAM CRD Schema

### DIFF
--- a/pkg/ipammachinery/client.go
+++ b/pkg/ipammachinery/client.go
@@ -17,44 +17,99 @@
 package ipammachinery
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	v1 "github.com/F5Networks/f5-ipam-controller/pkg/ipamapis/apis/fic/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	log "github.com/F5Networks/f5-ipam-controller/pkg/vlogger"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	typesV1 "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
+	"strings"
 )
 
-func (ipamCli *IPAMClient) Create(namespace string, obj *v1.F5IPAM) (*v1.F5IPAM, error) {
-	result := &v1.F5IPAM{}
-	err := ipamCli.restClient.Post().
-		Namespace(namespace).Resource("f5ipams").
-		Body(obj).Do(context.TODO()).Into(result)
-	return result, err
+const MAX_RETRIES = 10
+
+func (ipamCli *IPAMClient) Create(obj *v1.F5IPAM) (*v1.F5IPAM, error) {
+	return ipamCli.kubeCRClient.K8sV1().F5IPAMs(obj.Namespace).Create(context.TODO(), obj, metaV1.CreateOptions{})
 }
 
-func (ipamCli *IPAMClient) Update(namespace string, obj *v1.F5IPAM) (*v1.F5IPAM, error) {
-	result := &v1.F5IPAM{}
-	err := ipamCli.restClient.Put().
-		Namespace(namespace).Resource("f5ipams").
-		Name(obj.Name).
-		Body(obj).Do(context.TODO()).Into(result)
-	return result, err
+func (ipamCli *IPAMClient) Update(obj *v1.F5IPAM) (res *v1.F5IPAM, err error) {
+	name := obj.Name
+	namespace := obj.Namespace
+	spec := obj.Spec
+
+	for i := 0; i < MAX_RETRIES; i++ {
+		res, err = ipamCli.kubeCRClient.K8sV1().F5IPAMs(namespace).Update(context.TODO(), obj, metaV1.UpdateOptions{})
+		if err == nil {
+			return
+		}
+		// For any other error, return the nil resource and error
+		// For the below particular error try again
+		if !strings.Contains(err.Error(), "please apply your changes to the latest version") {
+			return
+		}
+		obj, err = ipamCli.Get(namespace, name)
+		if err != nil {
+			log.Errorf("Unable to find F5IPAM: %v/%v to update. Error: %v",
+				namespace, name, err)
+			return
+		}
+		obj.Spec = spec
+	}
+	return
 }
 
-func (ipamCli *IPAMClient) Delete(namespace, name string, options *meta_v1.DeleteOptions) error {
-	return ipamCli.restClient.Delete().
-		Namespace(namespace).Resource("f5ipams").
-		Name(name).Body(options).Do(context.TODO()).Error()
+func (ipamCli *IPAMClient) UpdateStatus(obj *v1.F5IPAM) (res *v1.F5IPAM, err error) {
+	name := obj.Name
+	namespace := obj.Namespace
+	status := obj.Status
+
+	for i := 0; i < MAX_RETRIES; i++ {
+		res, err = ipamCli.kubeCRClient.K8sV1().F5IPAMs(namespace).UpdateStatus(context.TODO(), obj, metaV1.UpdateOptions{})
+		if err == nil {
+			return
+		}
+		// For any other error, return the nil resource and error
+		// For the below particular error try again
+		if !strings.Contains(err.Error(), "please apply your changes to the latest version") {
+			return
+		}
+		obj, err = ipamCli.Get(namespace, name)
+		if err != nil {
+			log.Errorf("Unable to find F5IPAM: %v/%v to update status. Error: %v",
+				namespace, name, err)
+			return
+		}
+		obj.Status = status
+	}
+	return
+}
+
+func (ipamCli *IPAMClient) Patch(obj *v1.F5IPAM) (*v1.F5IPAM, error) {
+	var buf bytes.Buffer
+	_ = json.NewEncoder(&buf).Encode(obj)
+
+	return ipamCli.kubeCRClient.K8sV1().F5IPAMs(obj.Namespace).Patch(
+		context.TODO(),
+		obj.Name,
+		typesV1.StrategicMergePatchType,
+		buf.Bytes(),
+		metaV1.PatchOptions{
+			FieldManager: F5IPAMCtlr,
+		},
+		"spec")
+}
+
+func (ipamCli *IPAMClient) Delete(namespace, name string, options metaV1.DeleteOptions) error {
+	return ipamCli.kubeCRClient.K8sV1().F5IPAMs(namespace).Delete(context.TODO(), name, options)
 }
 
 func (ipamCli *IPAMClient) Get(namespace, name string) (*v1.F5IPAM, error) {
-	result := &v1.F5IPAM{}
-	err := ipamCli.restClient.Get().
-		Namespace(namespace).Resource("f5ipams").
-		Name(name).Do(context.TODO()).Into(result)
-	return result, err
+	return ipamCli.kubeCRClient.K8sV1().F5IPAMs(namespace).Get(context.TODO(), name, metaV1.GetOptions{})
 }
 
 func addKnownTypes(scheme *runtime.Scheme) error {
@@ -63,7 +118,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&v1.F5IPAM{},
 		&v1.F5IPAMList{},
 	)
-	meta_v1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	metaV1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
 }
 

--- a/pkg/ipammachinery/ipam.go
+++ b/pkg/ipammachinery/ipam.go
@@ -33,7 +33,8 @@ import (
 const (
 
 	// F5IPAM is a F5 Custom Resource Kind.
-	F5ipam = "F5IPAM"
+	F5ipam     = "F5IPAM"
+	F5IPAMCtlr = "F5 IPAM Controller"
 
 	CRDPlural        string = "f5ipams"
 	CRDGroup         string = "fic.f5.com"
@@ -121,7 +122,11 @@ func (ipamCli *IPAMClient) Stop() {
 // RegisterCRD creates schema of F5IPAM and registers it with Kubernetes/Openshift
 func RegisterCRD(clientset extClient.Interface) error {
 	crd := &apiextensionv1beta1.CustomResourceDefinition{
-		ObjectMeta: meta_v1.ObjectMeta{Name: FullCRDName},
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:          FullCRDName,
+			ManagedFields: []meta_v1.ManagedFieldsEntry{{Manager: F5IPAMCtlr}},
+		},
+
 		Spec: apiextensionv1beta1.CustomResourceDefinitionSpec{
 			Group:    CRDGroup,
 			Versions: CRDVersions,
@@ -129,6 +134,10 @@ func RegisterCRD(clientset extClient.Interface) error {
 			Names: apiextensionv1beta1.CustomResourceDefinitionNames{
 				Plural: CRDPlural,
 				Kind:   F5ipam,
+			},
+			Subresources: &apiextensionv1beta1.CustomResourceSubresources{
+				Status: &apiextensionv1beta1.CustomResourceSubresourceStatus{},
+				Scale:  nil,
 			},
 			Validation: &apiextensionv1beta1.CustomResourceValidation{OpenAPIV3Schema: &apiextensionv1beta1.JSONSchemaProps{
 				Type: "object",

--- a/pkg/orchestration/kubernetes.go
+++ b/pkg/orchestration/kubernetes.go
@@ -353,9 +353,13 @@ func (k8sc *K8sIPAMClient) processResponse() bool {
 					ipamRsc.Status.IPStatus = append(ipamRsc.Status.IPStatus, ipSpec)
 				}
 
-				_, err = k8sc.ipamCli.Update(ipamRsc.Namespace, ipamRsc)
+				_, err = k8sc.ipamCli.UpdateStatus(ipamRsc)
 				if err != nil {
-					log.Errorf("Unable to Update F5IPAM: %v/%v", metadata.namespace, metadata.name)
+					log.Errorf("Unable to Update F5IPAM: %v/%v\t Error: %v",
+						metadata.namespace,
+						metadata.name,
+						err.Error(),
+					)
 				}
 				log.Debugf("Updated: %v/%v with Status. With IP: %v for Request: %v",
 					metadata.namespace,
@@ -392,9 +396,13 @@ func (k8sc *K8sIPAMClient) processResponse() bool {
 						ipamRsc.Status.IPStatus[:index],
 						ipamRsc.Status.IPStatus[index+1:]...,
 					)
-					_, err = k8sc.ipamCli.Update(ipamRsc.Namespace, ipamRsc)
+					_, err = k8sc.ipamCli.UpdateStatus(ipamRsc)
 					if err != nil {
-						log.Errorf("Unable to Update F5IPAM: %v/%v", metadata.namespace, metadata.name)
+						log.Errorf("Unable to Update F5IPAM: %v/%v\t Error: %v",
+							metadata.namespace,
+							metadata.name,
+							err.Error(),
+						)
 					}
 				}
 				log.Debugf("Updated: %v/%v with Status. Removed %v",


### PR DESCRIPTION
Updaete machinery API

Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>

**Description**:  _Add subresource "status" to the schema so that spec update would not write to status and vice versa _

**Changes Proposed in PR**:

**Fixes**: #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation

## CRD Checklist
- [x] Updated required CR schema