### PR TITLE
Handle Resource Delete with Spec entries in other Resources

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -8,7 +8,8 @@ Added Functionality
 
 Bug Fixes
 `````````
-FIC does not allocate the last IP address specified in the ip range.
+* FIC does not allocate the last IP address specified in the ip range.
+* FIC freeing IP address on Resource Deletion though corresponding Spec entry is present in other Resources.
 
 
 0.1.2

--- a/pkg/ipammachinery/client.go
+++ b/pkg/ipammachinery/client.go
@@ -112,6 +112,15 @@ func (ipamCli *IPAMClient) Get(namespace, name string) (*v1.F5IPAM, error) {
 	return ipamCli.kubeCRClient.K8sV1().F5IPAMs(namespace).Get(context.TODO(), name, metaV1.GetOptions{})
 }
 
+func (ipamCli *IPAMClient) List(namespace string) ([]v1.F5IPAM, error) {
+	ipamList, err := ipamCli.kubeCRClient.K8sV1().F5IPAMs(namespace).List(context.TODO(), metaV1.ListOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return ipamList.Items, nil
+}
 func addKnownTypes(scheme *runtime.Scheme) error {
 	SchemeGroupVersion := schema.GroupVersion{Group: CRDGroup, Version: CRDVersion}
 	scheme.AddKnownTypes(SchemeGroupVersion,


### PR DESCRIPTION
Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>

**Description**:  _FIC is not checking if the spec entry of deleted resource is present in any other resources, and freeing the IP_

**Changes Proposed in PR**: FIC frees IP only if the spec entry is available only in the Deleted Resource

**Fixes**: #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation

## CRD Checklist
- [x] Updated required CR schema