### PR TITLE
Fix Release IP Address on 'A' Record creation failure

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -91,7 +91,15 @@ func (ctlr *Controller) runController() {
 			if ipAddr != "" {
 				log.Debugf("[CORE] Allocated IP: %v for Request: %v", ipAddr, req.String())
 				req.IPAddr = ipAddr
-				ctlr.Manager.CreateARecord(req)
+				ok := ctlr.Manager.CreateARecord(req)
+				if !ok {
+					req.IPAddr = ipAddr
+					ctlr.Manager.ReleaseIPAddress(req)
+					log.Errorf("[CORE] Unable to Create A Record with hostname: %v", req.HostName)
+					log.Infof("[CORE] Releasing Allocated IP: %v", ipAddr)
+
+					break
+				}
 				go sendResponse(req, ipAddr)
 			}
 		case ipamspec.DELETE:


### PR DESCRIPTION
Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>

**Description**:  _IP addresses are leaking_

**Changes Proposed in PR**: Release IP address just allocated if the subsequent action of creating A record fails

**Fixes**: #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation

## CRD Checklist
- [x] Updated required CR schema