### PR TITLE
Add support for standalone IP in Infoblox Provider

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -85,7 +85,8 @@ func (ctlr *Controller) runController() {
 			if ipAddr != "" {
 				req.IPAddr = ipAddr
 				ctlr.Manager.ReleaseIPAddress(req)
-				ctlr.Manager.DeleteARecord(req)
+				// Disabled DNSView (ARecords)
+				//ctlr.Manager.DeleteARecord(req)
 			}
 			go func(request ipamspec.IPAMRequest) {
 				resp := ipamspec.IPAMResponse{

--- a/pkg/manager/infobloxmanager.go
+++ b/pkg/manager/infobloxmanager.go
@@ -171,7 +171,7 @@ func (infMgr *InfobloxManager) DeleteARecord(req ipamspec.IPAMRequest) {
 
 // GetIPAddress Gets IP Address associated with hostname
 func (infMgr *InfobloxManager) GetIPAddress(req ipamspec.IPAMRequest) string {
-	if req.HostName == "" {
+	if req.HostName == "" && req.Key == "" {
 		log.Errorf("[IPMG] Invalid Request to Get IP Address: %+v", req)
 		return ""
 	}
@@ -187,13 +187,10 @@ func (infMgr *InfobloxManager) GetIPAddress(req ipamspec.IPAMRequest) string {
 	//	log.Errorf("[IPMG] No IP address available with Hostname to Get IP Address: %v", req.String())
 	//	return ""
 	//}
-	res := infMgr.getARecords(req)
 
-	if len(res) == 0 {
-		return ""
-	}
+	ip := infMgr.getIPAddressFromName(req)
 
-	return res[0].Ipv4Addr
+	return ip
 }
 
 // GetNextIPAddress Gets and reserves the next available IP address
@@ -202,7 +199,11 @@ func (infMgr *InfobloxManager) AllocateNextIPAddress(req ipamspec.IPAMRequest) s
 	if !ok {
 		return ""
 	}
-	fixedAddr, err := infMgr.objMgr.AllocateIP(infMgr.NetView, label.CIDR, "", "", "", infMgr.ea)
+	name := req.HostName
+	if req.Key != "" {
+		name = req.Key
+	}
+	fixedAddr, err := infMgr.objMgr.AllocateIP(infMgr.NetView, label.CIDR, "", "", name, infMgr.ea)
 	if err != nil {
 		log.Errorf("[IPMG] Unable to Get a New IP Address: %+v", req)
 		return ""
@@ -242,6 +243,38 @@ func (infMgr *InfobloxManager) getARecords(req ipamspec.IPAMRequest) []ibxclient
 		return nil
 	}
 	return res
+}
+
+func (infMgr *InfobloxManager) getIPAddressFromName(req ipamspec.IPAMRequest) (ip string) {
+	var returnFixedAddresses []ibxclient.FixedAddress
+
+	label, ok := infMgr.IBLabels[req.IPAMLabel]
+	if !ok {
+		return ""
+	}
+
+	name := req.HostName
+	if req.Key != "" {
+		name = req.Key
+	}
+
+	fixedAddr := ibxclient.NewFixedAddress(ibxclient.FixedAddress{
+		NetviewName: infMgr.NetView,
+		Cidr:        label.CIDR,
+	})
+
+	err := infMgr.connector.GetObject(fixedAddr, "", &returnFixedAddresses)
+	for _, fixedAddress := range returnFixedAddresses {
+		if fixedAddress.Name == name {
+			return fixedAddress.IPAddress
+		}
+	}
+
+	if err != nil || returnFixedAddresses == nil || len(returnFixedAddresses) == 0 {
+		log.Errorf("[Infoblox] IP not available, %+v", req)
+		return ""
+	}
+	return ""
 }
 
 func (infMgr *InfobloxManager) validateIPAMLabels(dnsView, cidr string) (bool, error) {


### PR DESCRIPTION
**Description**: Supporting all CRDs (VS CRDs, TS CRDs and ServiceType LB) in Infoblox and providing Unique IP without dependent on ARecord

**Changes Proposed in PR**:

**Fixes**: #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation

## CRD Checklist
- [x] Updated required CR schema