### PR TITLE
Persistent volume mount for default provider

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,6 +1,25 @@
 Release Notes for F5 IPAM Controller for Kubernetes & OpenShift
 =======================================================================
 
+Next-release
+------------
+Added Functionality
+```````````````````
+* Persistent volume mount support with F5 IPAM Controller default provider. (More details at `documentation <https://github.com/F5Networks/f5-ipam-controller/blob/main/README.md>`_).
+* Added support for
+    - Single NetView via deployment parameters. It need not be provided via IPAM Label.
+    - Standalone IP in Infoblox Provider.
+* `f5ipam` CRD is now renamed to `ipam`.
+* Disabled DNSView for Infoblox Provider
+
+Bug Fixes
+`````````
+* Stale status entries are cleared from IPAM custom resource.
+
+Known Issues
+```````````
+
+
 0.1.4
 ------------
 Added Functionality


### PR DESCRIPTION
**Description**:  Create db file from code. Added examples for local PV 

**Changes Proposed in PR**:
 - updated readme
- store.go - to create new db file if it doesn't exist

**Fixes**: internal CONTCNTR-2906

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature 
- [x] Updated the documentation - https://docs.f5net.com/display/~spondugula/Volume+Mount+for+IPAM+DB 
