### PR TITLE
Support for credentials-directory parameter for infoblox creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,12 @@ The F5 IPAM Controller acts as an interface to CIS to provide an IP address from
 | ------ | ------ | ------ | ------ |
 | infoblox-labels | String | Required | infoblox labels holds the mappings for infoblox's CIDR |
 | infoblox-grid-host | String | Required |  URL (or IP Address) of Infoblox Grid Host |
-| infoblox-wapi-port | String | Required | Port that the Infoblox Server listens on |
+| infoblox-wapi-port | String | Optional | Port that the Infoblox Server listens on. Default is 443 |
 | infoblox-wapi-version | String | Required | Web API version of Infoblox
 | infoblox-username | String | Required | Username of Infoblox User |
-| infoblox-username | String | Required | Password of the given Infoblox User |
+| infoblox-password | String | Required | Password of the given Infoblox User |
 | infoblox-netview | String | Required | Netview from which IP addresses needs to be allocated |
+| credentials-directory | String | Optional | Credentials can be mounted from k8s secrets |
 
 
 Note: On how to configure these Configuration Options, please refer to IPAM Deployment YAML example in below.

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -9,6 +9,7 @@ Added Functionality
 * Added support for
     - Single NetView via deployment parameters. It need not be provided via IPAM Label.
     - Standalone IP in Infoblox Provider.
+    - `credentials-directory` configuration option for mounting infoblox credentials from kubernetes secrets
 * `f5ipam` CRD is now renamed to `ipam`.
 * Disabled DNSView for Infoblox Provider
 

--- a/docs/config_examples/f5-ip-provider/README.md
+++ b/docs/config_examples/f5-ip-provider/README.md
@@ -1,0 +1,11 @@
+Refer to example deployments with default f5-ip-provider in this directory.
+
+## Static IPAM deployments with persistent volume mounts
+
+Kubernetes supports a wide variety of storage options. Refer [link](https://kubernetes.io/docs/concepts/storage/volumes) for more details.
+
+###### _Note:_ Example in this repo is just for demo purpose and is not suitable for production environment. Read through the limitations with each of the storage options and choose as per your production need. Please refer [cloudodcs](https://clouddocs.f5.com/containers/latest/userguide/ipam/) for more details.
+
+###### _Note:_  Local storage ties your application to a specific node as mentioned in nodeAffinity of PV yaml deployment.
+
+_Pre-requisite:_ Ensure mount directory (In example, `localstorage-pv-pvc-example.yaml`, /tmp/cis_ipam) to be present on node.

--- a/docs/config_examples/f5-ip-provider/default-provider-deployment-with-pv-mount.yaml
+++ b/docs/config_examples/f5-ip-provider/default-provider-deployment-with-pv-mount.yaml
@@ -1,0 +1,47 @@
+# Sample configuration for f5-ipam-controller with default provider. For persistent IP addresses upon restarts,
+# volume mounts are used. securityContext is used to change mount permissions to controller user.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    name: f5-ipam-controller
+  name: f5-ipam-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: f5-ipam-controller
+  template:
+    metadata:
+      labels:
+        app: f5-ipam-controller
+    spec:
+      containers:
+        - args:
+            - --orchestration
+            - kubernetes
+            - --ip-range
+            - '{"Dev":"172.16.3.21-172.16.3.30","Test":"172.16.3.31-172.16.3.40","Production":"172.16.3.41-172.16.3.50",
+                "Default":"172.16.3.51-172.16.3.60" } '
+            - --log-level
+            - DEBUG
+          command:
+            - /app/bin/f5-ipam-controller
+          image: f5networks/f5-ipam-controller:latest
+          imagePullPolicy: IfNotPresent
+          name: f5-ipam-controller
+          terminationMessagePath: /dev/termination-log
+          volumeMounts:
+            - mountPath: /app/ipamdb
+              name: samplevol
+      securityContext:
+        fsGroup: 1200
+        runAsGroup: 1200
+        runAsUser: 1200
+      serviceAccount: bigip-controller
+      serviceAccountName: bigip-controller
+      volumes:
+        - name: samplevol
+          persistentVolumeClaim:
+            claimName: pvc-local

--- a/docs/config_examples/f5-ip-provider/localstorage-pv-pvc-example.yaml
+++ b/docs/config_examples/f5-ip-provider/localstorage-pv-pvc-example.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-pv
+spec:
+  capacity:
+    storage: 1Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-storage
+  local:
+    path: /tmp/cis_ipam
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - <node-name>
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-local
+  namespace: kube-system
+spec:
+  storageClassName: local-storage
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 0.1Gi

--- a/docs/config_examples/infoblox/infoblox-credentials-secret.yaml
+++ b/docs/config_examples/infoblox/infoblox-credentials-secret.yaml
@@ -1,0 +1,12 @@
+# Secret with infoblox credentials
+apiVersion: v1
+kind: Secret
+metadata:
+  name: infoblox-credentials
+  namespace: kube-system
+type: Opaque
+data:
+  username: dXNlcg==
+  password: cGFzd2Q=
+  grid-host: MTAuMS4xLjE=
+  infoblox-port: NDQz

--- a/docs/config_examples/infoblox/infoblox-deployment-credentials-directory.yaml
+++ b/docs/config_examples/infoblox/infoblox-deployment-credentials-directory.yaml
@@ -1,0 +1,48 @@
+# Sample configuration for f5-ipam-controller with infoblox provider. Infoblox configuration is mounted
+# from the secret store into the controller.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    name: f5-ipam-controller
+  name: f5-ipam-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: f5-ipam-controller
+  template:
+    metadata:
+      labels:
+        app: f5-ipam-controller
+    spec:
+      containers:
+        - args:
+            - --orchestration=kubernetes
+            - --log-level=DEBUG
+            - --ipam-provider
+            - infoblox
+            - --infoblox-labels
+            - '{"Dev" :{"cidr": "172.16.4.0/24"},"Test" :{"cidr": "172.16.5.0/24"}}'
+            - --infoblox-wapi-version
+            - 2.11.2
+            - --infoblox-netview
+            - default
+            - --credentials-directory
+            - /tmp/creds
+          command:
+            - /app/bin/f5-ipam-controller
+          image: f5networks/f5-ipam-controller
+          imagePullPolicy: IfNotPresent
+          name: f5-ipam-controller
+          volumeMounts:
+            - name: infoblox-creds
+              mountPath: /tmp/creds
+              readOnly: true
+      volumes:
+      - name: infoblox-creds
+        secret:
+          secretName: infoblox-credentials
+      serviceAccount: ipam-ctlr
+      serviceAccountName: ipam-ctlr

--- a/docs/config_examples/infoblox/infoblox-deployment.yaml
+++ b/docs/config_examples/infoblox/infoblox-deployment.yaml
@@ -1,0 +1,44 @@
+# Sample configuration for f5-ipam-controller with infoblox provider. Infoblox credentials are passed directly in arguments
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    name: f5-ipam-controller
+  name: f5-ipam-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: f5-ipam-controller
+  template:
+    metadata:
+      labels:
+        app: f5-ipam-controller
+    spec:
+      containers:
+        - args:
+            - --orchestration=kubernetes
+            - --log-level=DEBUG
+            - --ipam-provider
+            - infoblox
+            - --infoblox-labels
+            - '{"Dev" :{"cidr": "172.16.4.0/24"},"Test" :{"cidr": "172.16.5.0/24"}}'
+            - --infoblox-grid-host
+            - 10.1.1.1
+            - --infoblox-wapi-port=443
+            - --infoblox-wapi-version
+            - 2.11.2
+            - --infoblox-username
+            - user
+            - --infoblox-password
+            - paswd
+            - --infoblox-netview
+            - default
+          command:
+            - /app/bin/f5-ipam-controller
+          image: f5networks/f5-ipam-controller
+          imagePullPolicy: IfNotPresent
+          name: f5-ipam-controller
+      serviceAccount: ipam-ctlr
+      serviceAccountName: ipam-ctlr

--- a/docs/config_examples/rbac.yaml
+++ b/docs/config_examples/rbac.yaml
@@ -1,0 +1,31 @@
+# RBAC -  ServiceAccount, ClusterRole and ClusterRoleBindings for F5 IPAM Controller
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ipam-ctlr-clusterrole
+rules:
+  - apiGroups: ["fic.f5.com"]
+    resources: ["ipams","ipams/status"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ipam-ctlr-clusterrole-binding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ipam-ctlr-clusterrole
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: ipam-ctlr
+    namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ipam-ctlr
+  namespace: kube-system
+


### PR DESCRIPTION
**Description**:  

* Support for credentials-directory parameter for infoblox creds
   - If any of these keys do not exist in secrets data, the controller falls back to using the CLI arguments as parameters.
* Added deployment examples to config_examples folder.  

**Changes Proposed in PR**:

**Fixes**: #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation

## CRD Checklist
- [x] Updated required CR schema