### PR TITLE
Skip no rows error log

### DIFF
--- a/docs/config_examples/f5-ip-provider/ipv6-addr-range-default-provider-deployment.yaml
+++ b/docs/config_examples/f5-ip-provider/ipv6-addr-range-default-provider-deployment.yaml
@@ -22,8 +22,8 @@ spec:
             - --orchestration
             - kubernetes
             - --ip-range
-            - '{"Dev":"10:8:3:21:0:6:7:ffff-10:8:3:21:0:6:8:3","Test":"10:8:3:31:0:6:7:1-10:8:3:31:0:6:7:9",
-                 "Production":"10:8:3:41:0:6:7:9-10:8:3:41:0:6:7:40","Default":"10:8:3:51:0:6:7:ffff-10:8:3:51:0:6:8:3" }'
+            - '{"Dev":"2001:db8:3::7-2001:db8:3::9","Test":"2001:db8:4::7-2001:db8:4::9",
+                 "Production":"2001:db8:5::ffff-2001:db8:6::9","Default":"2001:0db8:85a3:0000:0000:8a2e:0370:7334-2001:0db8:85a3:0000:0000:8a2e:0370:7340" }'
             - --log-level
             - DEBUG
           command:
@@ -39,8 +39,8 @@ spec:
         fsGroup: 1200
         runAsGroup: 1200
         runAsUser: 1200
-      serviceAccount: bigip-controller
-      serviceAccountName: bigip-controller
+      serviceAccount: ipam-ctlr
+      serviceAccountName: ipam-ctlr
       volumes:
         - name: samplevol
           persistentVolumeClaim:

--- a/docs/config_examples/f5-ip-provider/pv-mount-with-default-provider-deployment.yaml
+++ b/docs/config_examples/f5-ip-provider/pv-mount-with-default-provider-deployment.yaml
@@ -39,8 +39,8 @@ spec:
         fsGroup: 1200
         runAsGroup: 1200
         runAsUser: 1200
-      serviceAccount: bigip-controller
-      serviceAccountName: bigip-controller
+      serviceAccount: ipam-ctlr
+      serviceAccountName: ipam-ctlr
       volumes:
         - name: samplevol
           persistentVolumeClaim:

--- a/pkg/provider/sqlite/store.go
+++ b/pkg/provider/sqlite/store.go
@@ -252,7 +252,9 @@ func (store *DBStore) GetIPAddressFromReference(ipamLabel, reference string) str
 	)
 	err := store.db.QueryRow(queryString).Scan(&ipaddress, &status)
 	if err != nil {
-		log.Errorf("Unable to fetch IPAddress for reference %s with error %v", reference, err)
+		if err != sql.ErrNoRows {
+			log.Errorf("Unable to fetch IPAddress for host %s with error %v", reference, err)
+		}
 		return ""
 	}
 	if status == AVAILABLE {


### PR DESCRIPTION
**Description**:  
When new host requests for IP, an error -  `Unable to fetch IPAddress for reference nginx-ingress/nginx-ingress-service_svc with error sql: no rows in result set` is seen. This is confusing to end users. 

**Changes Proposed in PR**:
- Skipping to log this error
