### PR TITLE
Persistent Volume Claim support from helm chart and Adding tolerations support from helm

### DIFF
--- a/helm-charts/f5-ipam-controller/README.md
+++ b/helm-charts/f5-ipam-controller/README.md
@@ -27,27 +27,31 @@ This is the simplest way to install the FIC on OpenShift/Kubernetes cluster. Hel
     
 ## Chart parameters:
 
-| Parameter             | Required | Description                                                              | Default                       |
-|-----------------------|----------|--------------------------------------------------------------------------|-------------------------------|
- | rbac.create           | Optional | Create ClusterRole and ClusterRoleBinding                                | true                          |
- | serviceAccount.name   | Optional | name of the ServiceAccount for FIC controller                            | <chatname>-f5-ipam-controller |
- | serviceAccount.create | Optional | Create service account for the FIC controller                            | true                          |
- | namespace             | Optional | name of namespace FIC lives and watches for IPAM resources               | kube-system                   |
- | image.user            | Optional | FIC Controller image repository username                                 | f5networks                    |
-| image.repo            | Optional | FIC Controller image repository name                                     | f5-ipam-controller            |
-| image.pullPolicy      | Optional | FIC Controller image pull policy                                         | Always                        |
-| image.version         | Optional | FIC Controller image tag                                                 | NA                            |
- | volume.mountPath      | Optional | Mount Path that the controller places the DB file                        | NA                            |
- | volume.mountName      | Optional | Name of the volume mounted                                               | NA                            |
- | volume.pvc            | Optional | Persistent volume claim, using which enables controller to access volume | NA                            |
- | nodeSelector	         | Optional	| dictionary of Node selector labels	                                   | empty
- | tolerations	         |Optional	| Array of labels	                                                       | empty
- | limits_cpu	         | Optional	| CPU limits for the pod	                                               | 100m
- | limits_memory	     | Optional	| Memory limits for the pod                                                | 512Mi
- | requests_cpu	         | Optional | CPU request for the pod                                                  | 100m
- | requests_memory	     | Optional	| Memory request for the pod                                               | 512Mi
- | affinity	             | Optional	| Dictionary of affinity                                                   | empty
- | securityContext	     | Optional	| Dictionary of securityContext	                                           | empty
+| Parameter             | Required  | Description                                                | Default                        |
+|-----------------------|-----------|------------------------------------------------------------|--------------------------------|
+ | rbac.create           | Optional  | Create ClusterRole and ClusterRoleBinding                  | true                           |
+ | serviceAccount.name   | Optional  | name of the ServiceAccount for FIC controller              | <chatname>-f5-ipam-controller  |
+ | serviceAccount.create | Optional  | Create service account for the FIC controller              | true                           |
+ | namespace             | Optional  | name of namespace FIC lives and watches for IPAM resources | kube-system                    |
+ | image.user            | Optional  | FIC Controller image repository username                   | f5networks                     |
+| image.repo            | Optional  | FIC Controller image repository name                       | f5-ipam-controller             |
+| image.pullPolicy      | Optional  | FIC Controller image pull policy                           | Always                         |
+| image.version         | Optional  | FIC Controller image tag                                   | NA                             |
+| pvc.name              | Optional  | Name of the persistent volume claim for FIC controller     | <chartname>-f5-ipam-controller |
+| pvc.create            | Optional  | Create persistent volume claim for FIC controller          | false                          |
+| pvc.storageClassName  | Optional  | Name of the storage class                                  | NA                             |
+| pvc.accessMode        | Optional  | Access Mode for the volume                                 | ReadWriteOnce                             |
+| pvc.storage           | Optional  | Required storage for FIC controller volume                 | NA                             |
+| volume.mountPath      | Optional  | Mount Path that the controller places the DB file          | NA                             |
+| volume.mountName      | Optional  | Name of the volume mounted                                 | NA                             |
+| nodeSelector	         | Optional	 | dictionary of Node selector labels	                        | empty                          
+| tolerations	          | Optional	 | Array of labels	                                           | empty                          
+| limits_cpu	           | Optional	 | CPU limits for the pod	                                    | 100m                           
+| limits_memory	        | Optional	 | Memory limits for the pod                                  | 512Mi                          
+| requests_cpu	         | Optional  | CPU request for the pod                                    | 100m                           
+| requests_memory	      | Optional	 | Memory request for the pod                                 | 512Mi                          
+| affinity	             | Optional	 | Dictionary of affinity                                     | empty                          
+| securityContext	      | Optional	 | Dictionary of securityContext	                             | empty                          
 
 See the FIC documentation for a full list of args supported for FIC [FIC Configuration Options](https://github.com/F5Networks/f5-ipam-controller/blob/main/README.md)
 

--- a/helm-charts/f5-ipam-controller/templates/_helpers.tpl
+++ b/helm-charts/f5-ipam-controller/templates/_helpers.tpl
@@ -51,3 +51,15 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+
+ {{/*
+Create the name of the Persistent Volume Claim to use
+*/}}
+{{- define "f5-ipam-controller.persistentVolumeClaimName" -}}
+{{- if .Values.pvc.create -}}
+    {{ default (include "f5-ipam-controller.fullname" .) .Values.pvc.name }}
+{{- else -}}
+    {{ default "default" .Values.pvc.name }}
+{{- end -}}
+{{- end -}}

--- a/helm-charts/f5-ipam-controller/templates/f5-ipam-controller-deploy.yaml
+++ b/helm-charts/f5-ipam-controller/templates/f5-ipam-controller-deploy.yaml
@@ -119,6 +119,6 @@ spec:
       volumes:
       - name: {{ .Values.volume.mountName }}
         persistentVolumeClaim:
-          claimName: {{ .Values.volume.pvc }}
+          claimName: {{ template "f5-ipam-controller.persistentVolumeClaimName" . }}
   {{- end }}
 {{- end }}

--- a/helm-charts/f5-ipam-controller/templates/f5-ipam-controller-persistentvolumeclaim.yaml
+++ b/helm-charts/f5-ipam-controller/templates/f5-ipam-controller-persistentvolumeclaim.yaml
@@ -1,0 +1,25 @@
+{{- if and (eq .Values.args.provider "f5-ip-provider") (eq .Values.pvc.create true) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "f5-ipam-controller.persistentVolumeClaimName" . }}
+  namespace: {{ template "f5-ipam-controller.namespace" . }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "f5-ipam-controller.name" . }}
+    app: {{ template "f5-ipam-controller.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "-" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  storageClassName: {{ .Values.pvc.storageClassName }}
+  accessModes:
+    - {{ .Values.pvc.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.pvc.storage }}
+  {{- end }}
+
+
+

--- a/helm-charts/f5-ipam-controller/values.yaml
+++ b/helm-charts/f5-ipam-controller/values.yaml
@@ -60,7 +60,26 @@ image:
 # requests_cpu: 100m
 # requests_memory: 512Mi
 
+pvc:
+  # set create tag to true to create new persistent volume claim and set storageClassName,accessMode and storage
+  create: false
+
+  #name of the  persistent volume claim to be used
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+  #if create set to false below parameters will be ignored
+  storageClassName:
+  accessMode: ReadWriteOnce
+  storage:
+
 volume:
   mountPath: /app/ipamdb
   mountName: fic-volume-mount
-  pvc: fic-volume-claim
+
+# To enable tolerations, uncomment below block and customize key,effect,operator.
+# Below is just an example and different key,value and operators are also supported
+#tolerations:
+#  - key: "node-role.kubernetes.io/master"
+#    effect: "NoSchedule"
+#    operator: "Exists"


### PR DESCRIPTION
**Description**:  To simplify the deployment of the IPAM controller provide PVC creation part as well to it using HELM

**Changes Proposed in PR**:  Added support for PVC creation from HELM,  Added sample block of tolerations to helm - values.yaml

**Fixes**: #96 #102 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the troubleshooting guide or documentation

## CRD Checklist
- [x] Updated required CR schema