### PR TITLE
Add option to set IPAM Helm deployment update strategy to Recreate

### DIFF
--- a/helm-charts/f5-ipam-controller/templates/f5-ipam-controller-deploy.yaml
+++ b/helm-charts/f5-ipam-controller/templates/f5-ipam-controller-deploy.yaml
@@ -17,6 +17,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+{{- if .Values.updateStrategy }}
+  strategy:
+    type: {{  .Values.updateStrategy }}
+{{- end }}
   replicas: 1
   selector:
     matchLabels:

--- a/helm-charts/f5-ipam-controller/values.yaml
+++ b/helm-charts/f5-ipam-controller/values.yaml
@@ -60,6 +60,11 @@ image:
 # requests_cpu: 100m
 # requests_memory: 512Mi
 
+# updateStrategy is used to set the update strategy for f5-ipam-controller deployment.
+# The default update strategy is RollingUpdate, however if you want to set it to Recreate then uncomment the following line.
+# Note: Setting updateStrategy to Recreate may have some downtime during the update.
+#updateStrategy: Recreate
+
 pvc:
   # set create tag to true to create new persistent volume claim and set storageClassName,accessMode and storage
   create: false


### PR DESCRIPTION
**Description**:  Add option to set IPAM Helm deployment update strategy to Recreate

**Changes Proposed in PR**: Added option to set IPAM Helm deployment update strategy to Recreate in the values.yaml

**Fixes**: #130 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the troubleshooting guide or documentation

## CRD Checklist
- [x] Updated required CR schema