### PR TITLE
Update resource limits and requests for manager to avoid OOMKilled is…

### DIFF
--- a/f5-ipam-controller-operator/config/manager/manager.yaml
+++ b/f5-ipam-controller-operator/config/manager/manager.yaml
@@ -93,9 +93,9 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 256Mi
           requests:
-            cpu: 10m
-            memory: 64Mi
+            cpu: 100m
+            memory: 128Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
**Description**:
Working with F5 and a mutual customer today, found issues with default requests and limits for the manager pod causing OOMKilled errors when reconciling the IPAM CR. This should fix that.

**Changes Proposed in PR**:
Increased manager requests and limits to a reasonable allowance.

**Fixes**: #97