### PR TITLE
fix: correct .0 octet truncation in PaddedStringToIPV4

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -58,9 +59,17 @@ func Ipv4ToPaddedString(ip string) string {
 }
 func PaddedStringToIPV4(paddedIp string) string {
 	splitIp := strings.Split(paddedIp, ".")
-	if len(splitIp) == 4 {
-		return fmt.Sprintf("%s.%s.%s.%s", strings.TrimLeft(splitIp[0], "0"), strings.TrimLeft(splitIp[1], "0"), strings.TrimLeft(splitIp[2], "0"), strings.TrimLeft(splitIp[3], "0"))
-	} else {
+	if len(splitIp) != 4 {
 		return paddedIp
 	}
+	octets := make([]string, 4)
+	for i, o := range splitIp {
+		n, err := strconv.Atoi(o)
+		if err != nil {
+			// not a padded numeric octet; return input unchanged
+			return paddedIp
+		}
+		octets[i] = strconv.Itoa(n) // "000" -> "0", "082" -> "82"
+	}
+	return strings.Join(octets, ".")
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -27,4 +27,118 @@ var _ = Describe("Utils function test", func() {
 		Expect(IsIPAddr("")).To(BeFalse())
 		Expect(IsIPAddr("cdaskn")).To(BeFalse())
 	})
+
+	It("Ipv4ToPaddedString pads each octet to 3 digits", func() {
+		Expect(Ipv4ToPaddedString("10.65.82.0")).To(Equal("010.065.082.000"))
+		Expect(Ipv4ToPaddedString("10.65.83.0")).To(Equal("010.065.083.000"))
+		Expect(Ipv4ToPaddedString("0.0.0.0")).To(Equal("000.000.000.000"))
+		Expect(Ipv4ToPaddedString("10.65.82.1")).To(Equal("010.065.082.001"))
+		Expect(Ipv4ToPaddedString("10.65.82.10")).To(Equal("010.065.082.010"))
+		Expect(Ipv4ToPaddedString("10.65.82.20")).To(Equal("010.065.082.020"))
+		Expect(Ipv4ToPaddedString("192.168.1.100")).To(Equal("192.168.001.100"))
+		Expect(Ipv4ToPaddedString("255.255.255.255")).To(Equal("255.255.255.255"))
+	})
+
+	It("PaddedStringToIPV4 un-pads zero octets correctly (Ticket 000222)", func() {
+		// The .0-boundary cases that were previously truncated.
+		Expect(PaddedStringToIPV4("010.065.082.000")).To(Equal("10.65.82.0"))
+		Expect(PaddedStringToIPV4("010.065.083.000")).To(Equal("10.65.83.0"))
+		Expect(PaddedStringToIPV4("000.000.000.000")).To(Equal("0.0.0.0"))
+		// Any zero octet, not just the last one.
+		Expect(PaddedStringToIPV4("010.000.082.005")).To(Equal("10.0.82.5"))
+		Expect(PaddedStringToIPV4("000.065.082.001")).To(Equal("0.65.82.1"))
+	})
+
+	It("PaddedStringToIPV4 un-pads non-zero octets correctly", func() {
+		Expect(PaddedStringToIPV4("010.065.082.001")).To(Equal("10.65.82.1"))
+		Expect(PaddedStringToIPV4("010.065.082.010")).To(Equal("10.65.82.10"))
+		Expect(PaddedStringToIPV4("010.065.082.020")).To(Equal("10.65.82.20"))
+		Expect(PaddedStringToIPV4("192.168.001.100")).To(Equal("192.168.1.100"))
+		Expect(PaddedStringToIPV4("255.255.255.255")).To(Equal("255.255.255.255"))
+	})
+
+	It("PaddedStringToIPV4 returns input unchanged for non-IPv4 input", func() {
+		// IPv6 addresses do not have 4 dot-separated parts, so they pass through.
+		Expect(PaddedStringToIPV4("2000::ff23")).To(Equal("2000::ff23"))
+		Expect(PaddedStringToIPV4("2001:db8:85a3::8a2e:370:7334")).To(Equal("2001:db8:85a3::8a2e:370:7334"))
+		Expect(PaddedStringToIPV4("::1")).To(Equal("::1"))
+		// Malformed / non-numeric octets are returned unchanged rather than corrupted.
+		Expect(PaddedStringToIPV4("10.65.82")).To(Equal("10.65.82"))
+		Expect(PaddedStringToIPV4("10.65.82.abc")).To(Equal("10.65.82.abc"))
+		Expect(PaddedStringToIPV4("")).To(Equal(""))
+	})
+
+	It("IPv4 pad/un-pad round-trips without loss", func() {
+		ipv4Addrs := []string{
+			"10.65.82.0",
+			"10.65.83.0",
+			"0.0.0.0",
+			"255.255.255.255",
+			"10.65.82.1",
+			"10.65.82.10",
+			"10.65.82.20",
+			"192.168.1.100",
+			"172.16.1.1",
+			"10.0.0.0",
+		}
+		for _, ip := range ipv4Addrs {
+			Expect(PaddedStringToIPV4(Ipv4ToPaddedString(ip))).To(Equal(ip), "round-trip failed for %s", ip)
+		}
+	})
+
+	It("IPv6 addresses are not padded and survive the un-pad path", func() {
+		ipv6Addrs := []string{
+			"2000::ff23",
+			"2001:db8:85a3::8a2e:370:7334",
+			"::1",
+			"fe80::1",
+			"2001:0db8:0000:0000:0000:0000:0000:0001",
+		}
+		for _, ip := range ipv6Addrs {
+			// IPv6 addresses must never be altered by the IPv4 un-pad routine.
+			Expect(PaddedStringToIPV4(ip)).To(Equal(ip), "IPv6 address altered: %s", ip)
+			Expect(IsIPV6Addr(ip)).To(BeTrue(), "expected valid IPv6: %s", ip)
+		}
+	})
 })
+
+func TestPaddedStringToIPV4_ZeroOctets(t *testing.T) {
+	cases := map[string]string{
+		"010.065.082.000": "10.65.82.0", // .0 boundary (Ticket 000222)
+		"010.065.083.000": "10.65.83.0",
+		"000.000.000.000": "0.0.0.0",
+		"010.065.082.001": "10.65.82.1",
+		"010.065.082.010": "10.65.82.10",
+		"192.168.001.100": "192.168.1.100",
+	}
+	for padded, want := range cases {
+		if got := PaddedStringToIPV4(padded); got != want {
+			t.Errorf("PaddedStringToIPV4(%q) = %q, want %q", padded, got, want)
+		}
+	}
+}
+
+func TestPaddedRoundTrip(t *testing.T) {
+	for _, ip := range []string{"10.65.82.0", "0.0.0.0", "255.255.255.255", "10.65.82.10"} {
+		if got := PaddedStringToIPV4(Ipv4ToPaddedString(ip)); got != ip {
+			t.Errorf("round-trip %q = %q", ip, got)
+		}
+	}
+}
+
+func TestPaddedStringToIPV4_IPv6PassThrough(t *testing.T) {
+	// IPv6 addresses (and other non-4-octet strings) must be returned unchanged.
+	for _, ip := range []string{
+		"2000::ff23",
+		"2001:db8:85a3::8a2e:370:7334",
+		"::1",
+		"fe80::1",
+		"10.65.82",       // too few octets
+		"10.65.82.abc",   // non-numeric octet
+		"",               // empty
+	} {
+		if got := PaddedStringToIPV4(ip); got != ip {
+			t.Errorf("PaddedStringToIPV4(%q) = %q, want unchanged", ip, got)
+		}
+	}
+}


### PR DESCRIPTION

**Description**:  Fixes a regression where IPv4 addresses containing a .0 octet are truncated when read back from the SQLite store, producing invalid values in the IPAM CR status.
PaddedStringToIPV4() (pkg/utils/utils.go) un-pads stored addresses using strings.TrimLeft(octet, "0"). For an all-zero octet, "000" is stripped to "" instead of "0", so any address ending in (or containing) a 0 octet is corrupted on the read/write-back path — e.g. 10.65.82.0 (stored as 010.065.082.000) is reconstructed as 10.65.82., and 0.0.0.0 becomes .... This surfaces as IPStatus[N].ip: Invalid value: "10.65.82." on network-boundary addresses. The regression was introduced in d06b176 (#176) and shipped in v0.1.13.

**Changes Proposed in PR**:

- Rewrite PaddedStringToIPV4() to parse each octet numerically with strconv.Atoi and reprint it, so "000" -> "0" and "082" -> "82".
- Return the input unchanged for non-4-octet or non-numeric input, so IPv6 addresses and malformed strings pass through untouched (previous behavior preserved).
- No DB schema or storage-format change; stored padded values remain valid and are now decoded correctly (no data migration required).
- Add IPv4 and IPv6 unit tests in pkg/utils/utils_test.go covering .0 boundaries, 0.0.0.0, non-zero octets, pad/un-pad round-trips, and IPv6/malformed pass-through.

**Fixes**
NA

## General Checklist
- Updated Added functionality/ bug fix in release notes
- Added examples for new feature — N/A (bug fix, no new feature)
- Updated the troubleshooting guide or documentation — N/A (internal decode fix; no user-facing config change)

## CRD Checklist
 NA (no CR schema change)